### PR TITLE
Setup typecheck utilities

### DIFF
--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -1,3 +1,8 @@
+/**
+ * Checks if the value passed is an object
+ * @param {*} value
+ * @returns {boolean}
+ */
 export function isObject (value) {
     if (value === null) return false;
     if (Array.isArray(value)) return false;

--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -17,3 +17,12 @@ export function isObject (value) {
 export function isArray(value) {
     return Array.isArray(value);
 }
+
+/**
+ * Checks if the value passed is a string
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isString(value) {
+    return typeof value === 'string';
+}

--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -3,3 +3,12 @@ export function isObject (value) {
     if (Array.isArray(value)) return false;
     return (typeof value === 'object');
 }
+
+/**
+ * Checks if the value passed is an array
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isArray(value) {
+    return Array.isArray(value);
+}

--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -38,3 +38,12 @@ export function isNumber(value) {
     if (value == Infinity) return false;
     return typeof value === 'number';
 }
+
+/**
+ * Checks if the value passed is a boolean
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isBoolean(value) {
+    return typeof value === 'boolean';
+}

--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -26,3 +26,15 @@ export function isArray(value) {
 export function isString(value) {
     return typeof value === 'string';
 }
+
+/**
+ * Checks if the value passed is a number.
+ * (NaN and Infinity are not considered to be numbers.)
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isNumber(value) {
+    if (isNaN(value)) return false;
+    if (value == Infinity) return false;
+    return typeof value === 'number';
+}

--- a/src/utilities/typecheck.js
+++ b/src/utilities/typecheck.js
@@ -47,3 +47,12 @@ export function isNumber(value) {
 export function isBoolean(value) {
     return typeof value === 'boolean';
 }
+
+/**
+ * Checks if the value passed is a function
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isFunction(value) {
+    return typeof value === 'function';
+}

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -95,7 +95,7 @@ describe('isBoolean', () => {
     test.each([
         [true],
         [false]
-    ])(`returns 'true' for booleans (%b)`, (boolean) => {
+    ])(`returns 'true' for booleans (%p)`, (boolean) => {
         const result = isBoolean(boolean);
         expect(result).toBeTruthy();
     })

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -32,7 +32,8 @@ describe('isArray', () => {
         ['string'],
         [10],
         [false],
-        [null]
+        [null],
+        [undefined]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isArray(param);
         expect(result).toBeFalsy();

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -4,6 +4,7 @@ import {
     isString,
     isNumber,
     isBoolean,
+    isFunction,
 } from './typecheck';
 
 describe('isObject', () => {
@@ -109,6 +110,28 @@ describe('isBoolean', () => {
         [Infinity]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isBoolean(param);
+        expect(result).toBeFalsy();
+    })
+})
+
+describe('isFunction', () => {
+    it(`returns 'true' for functions`, () => {
+        const fn = () => {};
+        const result = isFunction(fn);
+        expect(result).toBeTruthy();
+    })
+    test.each([
+        [{}],
+        [[]],
+        ['string'],
+        [10],
+        [false],
+        [null],
+        [undefined],
+        [NaN],
+        [Infinity]
+    ])(`returns 'false' for other types (%#)`, (param) => {
+        const result = isFunction(param);
         expect(result).toBeFalsy();
     })
 })

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -1,6 +1,7 @@
 import { 
     isObject,
     isArray,
+    isString,
 } from './typecheck';
 
 describe('isObject', () => {
@@ -24,8 +25,8 @@ describe('isObject', () => {
 
 describe('isArray', () => {
     it(`returns 'true' for arrays`, () => {
-        const object = [];
-        const result = isArray(object);
+        const array = [];
+        const result = isArray(array);
         expect(result).toBeTruthy();
     })
     test.each([

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -3,6 +3,7 @@ import {
     isArray,
     isString,
     isNumber,
+    isBoolean,
 } from './typecheck';
 
 describe('isObject', () => {
@@ -85,6 +86,29 @@ describe('isNumber', () => {
         [Infinity]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isNumber(param);
+        expect(result).toBeFalsy();
+    })
+})
+
+describe('isBoolean', () => {
+    test.each([
+        [true],
+        [false]
+    ])(`returns 'true' for booleans (%b)`, (boolean) => {
+        const result = isBoolean(boolean);
+        expect(result).toBeTruthy();
+    })
+    test.each([
+        [{}],
+        [[]],
+        ['string'],
+        [10],
+        [null],
+        [undefined],
+        [NaN],
+        [Infinity]
+    ])(`returns 'false' for other types (%#)`, (param) => {
+        const result = isBoolean(param);
         expect(result).toBeFalsy();
     })
 })

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -14,7 +14,8 @@ describe('isObject', () => {
         ['string'],
         [10],
         [false],
-        [null]
+        [null],
+        [undefined]
     ])(`returns 'false' for non-objects (%#)`, (param) => {
         const result = isObject(param);
         expect(result).toBeFalsy();

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -21,7 +21,8 @@ describe('isObject', () => {
         [null],
         [undefined],
         [NaN],
-        [Infinity]
+        [Infinity],
+        [() => {}]
     ])(`returns 'false' for non-objects (%#)`, (param) => {
         const result = isObject(param);
         expect(result).toBeFalsy();
@@ -42,7 +43,8 @@ describe('isArray', () => {
         [null],
         [undefined],
         [NaN],
-        [Infinity]
+        [Infinity],
+        [() => {}]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isArray(param);
         expect(result).toBeFalsy();
@@ -63,7 +65,8 @@ describe('isString', () => {
         [null],
         [undefined],
         [NaN],
-        [Infinity]
+        [Infinity],
+        [() => {}]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isString(param);
         expect(result).toBeFalsy();
@@ -84,7 +87,8 @@ describe('isNumber', () => {
         [null],
         [undefined],
         [NaN],
-        [Infinity]
+        [Infinity],
+        [() => {}]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isNumber(param);
         expect(result).toBeFalsy();
@@ -107,7 +111,8 @@ describe('isBoolean', () => {
         [null],
         [undefined],
         [NaN],
-        [Infinity]
+        [Infinity],
+        [() => {}]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isBoolean(param);
         expect(result).toBeFalsy();

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -2,6 +2,7 @@ import {
     isObject,
     isArray,
     isString,
+    isNumber,
 } from './typecheck';
 
 describe('isObject', () => {
@@ -57,6 +58,27 @@ describe('isString', () => {
         [undefined]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isString(param);
+        expect(result).toBeFalsy();
+    })
+})
+
+describe('isNumber', () => {
+    it(`returns 'true' for numbers`, () => {
+        const number = 10;
+        const result = isNumber(number);
+        expect(result).toBeTruthy();
+    })
+    test.each([
+        [{}],
+        [[]],
+        ['string'],
+        [true],
+        [null],
+        [undefined],
+        [NaN],
+        [Infinity]
+    ])(`returns 'false' for other types (%#)`, (param) => {
+        const result = isNumber(param);
         expect(result).toBeFalsy();
     })
 })

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -40,3 +40,22 @@ describe('isArray', () => {
         expect(result).toBeFalsy();
     })
 })
+
+describe('isString', () => {
+    it(`returns 'true' for strings`, () => {
+        const string = 'string';
+        const result = isString(string);
+        expect(result).toBeTruthy();
+    })
+    test.each([
+        [{}],
+        [[]],
+        [10],
+        [true],
+        [null],
+        [undefined]
+    ])(`returns 'false' for other types (%#)`, (param) => {
+        const result = isString(param);
+        expect(result).toBeFalsy();
+    })
+})

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -17,7 +17,9 @@ describe('isObject', () => {
         [10],
         [false],
         [null],
-        [undefined]
+        [undefined],
+        [NaN],
+        [Infinity]
     ])(`returns 'false' for non-objects (%#)`, (param) => {
         const result = isObject(param);
         expect(result).toBeFalsy();
@@ -36,7 +38,9 @@ describe('isArray', () => {
         [10],
         [false],
         [null],
-        [undefined]
+        [undefined],
+        [NaN],
+        [Infinity]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isArray(param);
         expect(result).toBeFalsy();
@@ -55,7 +59,9 @@ describe('isString', () => {
         [10],
         [true],
         [null],
-        [undefined]
+        [undefined],
+        [NaN],
+        [Infinity]
     ])(`returns 'false' for other types (%#)`, (param) => {
         const result = isString(param);
         expect(result).toBeFalsy();

--- a/src/utilities/typecheck.spec.js
+++ b/src/utilities/typecheck.spec.js
@@ -1,4 +1,7 @@
-import { isObject } from './typecheck';
+import { 
+    isObject,
+    isArray,
+} from './typecheck';
 
 describe('isObject', () => {
     it(`returns 'true' for objects`, () => {
@@ -14,6 +17,24 @@ describe('isObject', () => {
         [null]
     ])(`returns 'false' for non-objects (%#)`, (param) => {
         const result = isObject(param);
+        expect(result).toBeFalsy();
+    })
+})
+
+describe('isArray', () => {
+    it(`returns 'true' for arrays`, () => {
+        const object = [];
+        const result = isArray(object);
+        expect(result).toBeTruthy();
+    })
+    test.each([
+        [{}],
+        ['string'],
+        [10],
+        [false],
+        [null]
+    ])(`returns 'false' for other types (%#)`, (param) => {
+        const result = isArray(param);
         expect(result).toBeFalsy();
     })
 })

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -1,9 +1,22 @@
 import { renderTemplate } from './template';
-import { isObject } from './typecheck';
+import {
+    isObject,
+    isArray,
+    isString,
+    isNumber,
+    isBoolean,
+    isFunction
+} from './typecheck';
 
 const utilities = {
     renderTemplate,
+    
     isObject,
+    isArray,
+    isString,
+    isNumber,
+    isBoolean,
+    isFunction,
 };
 
 export default utilities;


### PR DESCRIPTION
## ✨ Proposed Changes

In #2 an `isObject` function was added to the utilities. I've decided to expand the idea of that function by creating shortcuts for all common type checks. The following functions are now available:

- `isObject`
- `isArray`
- `isNumber`
- `isString`
- `isBoolean`
- `isFunction`