### PR TITLE
Setup getHTMLElement method on component

### DIFF
--- a/src/system/Component.js
+++ b/src/system/Component.js
@@ -40,7 +40,7 @@ export default class Component {
      * @memberof Component
      */
     update() {
-        const element = getDOMNode(this);
+        const element = this.getHTMLElement();
         if (element) {
             const newElement = toDOMNode(this.render());
             element.replaceWith(newElement);
@@ -88,6 +88,17 @@ export default class Component {
     }
 
     /**
+     * Get the HTMLElement for the component by querying the document for an element with the
+     * id of the component.
+     *
+     * @returns {(HTMLElement|null)} Returns the first element with the same component id. Or null if not found.
+     * @memberof Component
+     */
+    getHTMLElement() {
+        return document.querySelector(`[data-component-id="${this.id}"]`);
+    }
+
+    /**
      * Clean up any side effects that the Component has created
      * 
      * @returns {void}
@@ -125,7 +136,7 @@ function containsElement(query, target) {
 function registerDOMMutationObserver(component) {
     const config = { childList: true, subtree: true };
     const observer = new MutationObserver(mutations => {
-        const $component = getDOMNode(component);
+        const $component = component.getHTMLElement();
         const wasUpdated = mutations
             .map(mutation => mutation.addedNodes)
             .map(nodeList => [...nodeList])
@@ -160,10 +171,6 @@ function cleanUpEffects(component) {
 
 function registerEventListeners(component) {
     if (isFunction(component.events)) component.events();
-}
-
-function getDOMNode(component) {
-    return document.querySelectorAll(`[data-component-id="${component.id}"]`)[0];
 }
 
 function verifyHasView(component) {

--- a/src/system/__tests__/Component.spec.js
+++ b/src/system/__tests__/Component.spec.js
@@ -225,6 +225,21 @@ describe('on', () => {
     })
 })
 
+describe('getHTMLElement', () => {
+    it('returns the HTMLElement if the component is rendered to the document', () => {
+        const component = new MockComponent();
+        document.body.innerHTML = component.render();
+        const el = document.body.firstChild;
+        expect(component.getHTMLElement()).toBe(el);
+        component.cleanup();
+    })
+    it('returns [null] if the component is not rendered to the document', () => {
+        const component = new MockComponent();
+        expect(component.getHTMLElement()).toBe(null);
+        component.cleanup();
+    })
+})
+
 function MockComponent(view = '<div></div>') {
     let _this = new Component();
     _this.render = jest.fn(Component.prototype.render);


### PR DESCRIPTION
## 🛠 Proposed Changes

This PR moves the `getDOMNode` helper function in the `Component` file to an actual method (`getHTMLElement`) on the `Component` object. This way it can be used from the outside—by components themselves, or even from outside a component.