### PR TITLE
Setup two way data binding for the state of two components

### DIFF
--- a/src/system/Component.js
+++ b/src/system/Component.js
@@ -65,6 +65,7 @@ export default class Component {
         else if (isFunction(state)) newState = state(this.state);
         this.state = { ...this.state, ...newState };
         this.update();
+        runBindings(this, newState);
     }
 
     /**
@@ -85,6 +86,32 @@ export default class Component {
         document.addEventListener(event, (e) => {
             if (containsElement(query, e.target)) handler(e);
         }, options);
+    }
+
+    /**
+     * Setup two-way data binding beteween a property on the components' state
+     * and a property on another component's state 
+     *
+     * @param {string} property
+     * @param {Component} otherComponent
+     * @param {*} [otherProperty]
+     * @returns {void}
+     * @memberof Component
+     */
+
+    /**
+     * Setup two-way data binding beteween a property on the components' state
+     * and a property on another component's state.
+     *
+     * @param {string} property
+     * @param {Component} otherComponent
+     * @param {string} [otherProperty=property]
+     * @returns {void}
+     * @memberof Component
+     */
+    bind(property, otherComponent, otherProperty = property) {
+        setupOneWayDataBinding(this, property, otherComponent, otherProperty);
+        setupOneWayDataBinding(otherComponent, otherProperty, this, property);
     }
 
     /**
@@ -173,6 +200,23 @@ function cleanUpEffects(component) {
 
 function registerEventListeners(component) {
     if (isFunction(component.events)) component.events();
+}
+
+function setupOneWayDataBinding(component, property, otherComponent, otherProperty) {
+    if (!component._bindings) component._bindings = [];
+    function handler (newState) {
+        if (!newState.hasOwnProperty(property)) return;
+        if (otherComponent.state[otherProperty] === newState[property]) return;
+        otherComponent.setState({ 
+            [otherProperty]: newState[property] 
+        });
+    }
+    component._bindings.push(handler);
+}
+
+function runBindings(component, newState) {
+    if (! isArray(component._bindings)) return;
+    component._bindings.forEach(handle => handle(newState));
 }
 
 function verifyHasView(component) {

--- a/src/system/Component.js
+++ b/src/system/Component.js
@@ -90,17 +90,6 @@ export default class Component {
 
     /**
      * Setup two-way data binding beteween a property on the components' state
-     * and a property on another component's state 
-     *
-     * @param {string} property
-     * @param {Component} otherComponent
-     * @param {*} [otherProperty]
-     * @returns {void}
-     * @memberof Component
-     */
-
-    /**
-     * Setup two-way data binding beteween a property on the components' state
      * and a property on another component's state.
      *
      * @param {string} property

--- a/src/system/__tests__/Component.spec.js
+++ b/src/system/__tests__/Component.spec.js
@@ -253,6 +253,43 @@ describe('getHTMLElement', () => {
     })
 })
 
+describe('bind', () => {
+    describe('when the property on the components\' state changes', () => {
+        it('updates the value on the linked components state', () => {
+            const value = 'foo';
+            const component = new Component();
+            const otherComponent = new Component();
+            component.bind('property', otherComponent);
+            component.setState({ property: value });
+            expect(otherComponent.state.property).toBe(value);
+            component.cleanup();
+            otherComponent.cleanup();
+        })
+    })
+    describe('when the property on the linked components\' state changes', () => {
+        it('updates the value on the initial components state', () => {
+            const value = 'foo';
+            const component = new Component();
+            const otherComponent = new Component();
+            component.bind('property', otherComponent);
+            otherComponent.setState({ property: value });
+            expect(component.state.property).toBe(value);
+            component.cleanup();
+            otherComponent.cleanup();
+        })
+    })
+    it('accepts an optional parameter to specify the name of the property on the source component', () => {
+        const value = 'foo';
+        const component = new Component();
+        const otherComponent = new Component();
+        component.bind('property', otherComponent, 'otherProperty');
+        component.setState({ property: value });
+        expect(otherComponent.state.otherProperty).toBe(value);
+        component.cleanup();
+        otherComponent.cleanup();
+    })
+})
+
 function MockComponent(view = '<div></div>') {
     let _this = new Component();
     _this.render = jest.fn(Component.prototype.render);


### PR DESCRIPTION
## 🛠 Proposed Changes

This PR introduces a way up setup two-way data binding between properties on the state of two components. This means that whenever a specified property is updated on the first component, a specified property on the linked component is updated to match the same value, and vice versa.

The proposed API for this is the following:

```js
component.bind('localProperty', otherComponent, 'otherProperty');
```

This will bind `component.state.localProperty` to `otherComponent.state.otherProperty`. Which means that if you execute either of the following lines, both properties on both components will reflect the same new value. Notice how we only have to setup the binding once.

```js
component.setState({ localProperty: 'new value' });
// component.state.localProperty -> 'newValue'
// otherComponent.state.otherProperty -> 'newValue'

otherComponent.setState({ otherProperty: 'new value' });
// otherComponent.state.otherProperty -> 'newValue'
// component.state.localProperty -> 'newValue'
```

You can omit the 3th parameter—which specifies the name of the property on the other component. It will default mirror the property name across both components.

```js
component.bind('foo', otherComponent);
component.setState({ foo: 'bar' });

component.state.foo; // -> 'bar';
otherComponent.state.foo; // -> 'bar';
```

The current implementation allows you to chain bindings across multiple components. Consider the following:

```js
/* a.foo <---> b.bar <---> c.baz */

a.bind('foo', b, 'bar');
c.bind('baz', b, 'bar');

a.setState({ foo: 'derp' });

a.state.foo; // -> 'derp';
b.state.bar; // -> 'derp';
c.state.baz; // -> 'derp';
```